### PR TITLE
Don't use whereis -b to fix compilation on some systems.

### DIFF
--- a/.default
+++ b/.default
@@ -13,8 +13,8 @@ VERSION = 0.9.9
 LANG_LIST ?= de fr es it nl pl ru sk tr uk zh_CN zh_TW
 
 YEAR = $(shell date +%Y)
-ECHO = $(shell whereis -b echo | awk '{print $$2}')
-PRINTF = $(shell whereis -b printf | awk '{print $$2}')
+ECHO = $(shell which echo)
+PRINTF = $(shell which printf)
 
 PREFIX = /usr/local
 ETCDIR = $(PREFIX)/etc/xdg

--- a/configure
+++ b/configure
@@ -25,9 +25,9 @@ if [ -z "$CFLAGS" ]; then
   CFLAGS="-Wall -O -g"
 fi
 
-MAKE=`whereis -b make | awk '{print $2}'`
-ECHO=`whereis -b echo | awk '{print $2}'`
-PRINTF=`whereis -b printf | awk '{print $2}'`
+MAKE=`which make`
+ECHO=`which echo`
+PRINTF=`which printf`
 
 ERR()
 {
@@ -83,7 +83,7 @@ if [ "$1" = "-h" -o "$1" = "--help" -o "$1" = "-help" ]; then
   exit 0
 fi
 
-PKGCONFIG=`whereis -b pkg-config | awk '{print $2}'`
+PKGCONFIG=`which pkg-config`
 if [ -z "$PKGCONFIG" ]; then
   $ECHO ""
   ERR "ERROR: pkg-config package is needed to run this configure script. ABORT!\n"
@@ -239,7 +239,7 @@ fi
 
 if [ "$NLS" = 'Y' ]; then
   $ECHO -n "... testing Native Language Support : "
-  GETTEXT=`whereis -b msgfmt | awk '{print $2}'`
+  GETTEXT=`which msgfmt`
   if [ -z "$GETTEXT" ]; then
     if [ $NLS_SPC -eq 1 ]; then
       ERR "not found. Please install gettext package. ABORT!\n"
@@ -297,7 +297,7 @@ fi
 if [ "$STRIP" = 'Y' ]; then
   IMPORTANT "STRIP     = $STRIP\n"
 fi
-CHECK_CC=`whereis -b $CC | awk '{print $2}'`
+CHECK_CC=`which "$CC"`
 if [ -n "$CHECK_CC" ]; then
   if [ "$CC" != 'gcc' ]; then
     IMPORTANT "CC        = $CC\n"

--- a/po/Makefile
+++ b/po/Makefile
@@ -4,7 +4,7 @@ include ../.default
 PO_LIST ?= $(LANG_LIST:=.po)
 MO_LIST ?= $(LANG_LIST:=.mo)
 
-XGETTEXT := $(shell whereis -b xgettext | awk '{print $$2}')
+XGETTEXT := $(shell which xgettext)
 ifneq ($(XGETTEXT), )
 
 XGETTEXT_PARAMETER = -k_
@@ -31,7 +31,7 @@ endif
 
 endif
 
-MSGCMP := $(shell whereis -b msgcmp | awk '{print $$2}')
+MSGCMP := $(shell which msgcmp)
 ifneq ($(MSGCMP), )
 
 SUPPORT_USE_UNTRANSLATED = $(shell $(MSGCMP) --help | grep -q -- '--use-untranslated' && echo Y)
@@ -41,7 +41,7 @@ endif
 
 endif
 
-MSGMERGE := $(shell whereis -b msgmerge | awk '{print $$2}')
+MSGMERGE := $(shell which msgmerge)
 ifneq ($(MSGMERGE), )
 
 SUPPORT_PREVIOUS = $(shell $(MSGMERGE) --help | grep -q -- '--previous' && echo Y)
@@ -51,8 +51,8 @@ endif
 
 endif
 
-MSGFMT := $(shell whereis -b msgfmt | awk '{print $$2}')
-TOUCH := $(shell whereis -b touch | awk '{print $$2}')
+MSGFMT := $(shell which msgfmt)
+TOUCH := $(shell which touch)
 
 .PHONY: all
 all: $(MO_LIST)

--- a/src/Makefile
+++ b/src/Makefile
@@ -20,7 +20,7 @@
 include ../.default
 -include ../.config
 
-PKGCONFIG := $(shell whereis -b pkg-config | awk '{print $$2}')
+PKGCONFIG := $(shell which pkg-config)
 
 VTE ?= ""
 

--- a/src/unit_test.sh
+++ b/src/unit_test.sh
@@ -66,8 +66,8 @@ for opt do
 	esac
 done
 
-ECHO=`whereis -b echo | awk '{print $2}'`
-PRINTF=`whereis -b printf | awk '{print $2}'`
+ECHO=`which echo`
+PRINTF=`which printf`
 
 CHECK_INCLUDES=`$ECHO "$INCLUDES" | grep -- '-DUNIT_TEST'`
 if [ -z "$CHECK_INCLUDES" ]; then
@@ -79,7 +79,7 @@ if [ -z "$CHECK_INCLUDES" ]; then
 fi
 
 
-PKGCONFIG=`whereis -b pkg-config | awk '{print $2}'`
+PKGCONFIG=`which pkg-config`
 if [ -z "$PKGCONFIG" ]; then
 	$PRINTF "\x1b\x5b1;31m** ERROR: Command pkg-config is not found!\x1b\x5b0m\n"
 	exit 1


### PR DESCRIPTION
Reason: on some systems with /usr/bin/xgettext and /usr/bin/xgettext.pl,
whereis -b xgettext prints the .pl one first, causing the compilation
to fail (xgettext.pl reports unknown options).
