### PR TITLE
Add the missing "System" category required by FDO menu specification

### DIFF
--- a/data/lilyterm.desktop
+++ b/data/lilyterm.desktop
@@ -16,4 +16,4 @@ Exec=lilyterm
 Icon=lilyterm
 Type=Application
 Terminal=false
-Categories=GTK;Utility;TerminalEmulator;
+Categories=GTK;Utility;System;TerminalEmulator;


### PR DESCRIPTION
Just run "desktop-file-validate lilyterm.desktop" and see the warning message if this commit is not present. Also see http://standards.freedesktop.org/menu-spec/latest/apa.html .

Actually, I think the better fix is just only using the "System" catetory and remove the "Utilitiy" category.  That avoids the duplicated entries in both menus/categories. And that is exactly what xterm is doing. I will leave the removing thing for the maintainer to decide.
