### PR TITLE
Fix compilation failure by missing #includes

### DIFF
--- a/src/dialog.c
+++ b/src/dialog.c
@@ -17,6 +17,8 @@
  * along with LilyTerm.  If not, see <http://www.gnu.org/licenses/>.
  */
 
+#include <locale.h>
+
 #include "dialog.h"
 #define TEMPSTR 6
 

--- a/src/notebook.c
+++ b/src/notebook.c
@@ -17,6 +17,8 @@
  * along with LilyTerm.  If not, see <http://www.gnu.org/licenses/>.
  */
 
+#include <locale.h>
+
 #include "notebook.h"
 
 // GtkWidget *current_vte=NULL;


### PR DESCRIPTION
dialog.c: In function 'dialog':
dialog.c:116:2: warning: implicit declaration of function 'setlocale' [-Wimplicit-function-declaration]
dialog.c:116:12: error: 'LC_MESSAGES' undeclared (first use in this function)
