### PR TITLE
Use xdg-open instead of firefox

### DIFF
--- a/data/lilyterm.conf
+++ b/data/lilyterm.conf
@@ -574,21 +574,21 @@ web_environ =
 web_locale = 
 
 # The ftp client using for ftp(s)://
-ftp_client = firefox
+ftp_client = xdg-open
 ftp_method = 1
 ftp_VTE_CJK_WIDTH = 0
 ftp_environ = 
 ftp_locale = 
 
 # The file manager using for file:// and [Open current directory with file manager]
-file_manager = firefox
+file_manager = xdg-open
 file_method = 1
 file_VTE_CJK_WIDTH = 0
 file_environ = 
 file_locale = 
 
 # The email client using for user@host
-email_client = thunderbird
+email_client = xdg-open
 email_method = 1
 email_VTE_CJK_WIDTH = 0
 email_environ = 


### PR DESCRIPTION
xdg-open will automatically choose the right browser (the default one). It should come with every system running X11.
