### PR TITLE
Data transport to running process failed when '\n' is part of transported data.

### DIFF
--- a/src/main.c
+++ b/src/main.c
@@ -610,17 +610,18 @@ gboolean read_socket(GIOChannel *channel, GIOCondition condition, gpointer user_
 	GError *error = NULL;
 	gchar *data = NULL, **datas;
 	gsize len = 0;
-	gsize term;
 
-	if (g_io_channel_read_line (channel, &data, &len, &term, &error) == G_IO_STATUS_ERROR)
+	if (g_io_channel_read_to_end (channel, &data, &len, &error) != G_IO_STATUS_NORMAL)
 		return socket_fault(7, error, channel, TRUE);
+
 	// g_debug("Read %ld bytes from Lilyterm socket: '%s'", len, data);
 	if (len > 0)
 	{
 		//	     0			 1     2	   3	    4		5   6	 7		   8		9	      10      11
 		// get data: SOCKET_DATA_VERSION SHELL LOCALE_LIST ENCODING LC_MESSAGES PWD HOME VTE_CJK_WIDTH_STR wmclass_name wmclass_class ENVIRON ARGV
 		// clear '\n' at the end of data[]
-		data[len-1] = 0;
+		// this is nonsense, when no '\n' was written.
+		// data[len-1] = 0;
 
 		datas = split_string(data, "\x10", 12);
 		// g_debug("The SOCKET_DATA_VERSION = %s ,and the data sent via socket is %s",

--- a/src/main.c
+++ b/src/main.c
@@ -498,9 +498,23 @@ gboolean send_socket( int   argc,
 		// main_channel is NULL, so that we don't need to launch clear_channel()
 		return socket_fault(11, error, channel, TRUE);
 	// flush writing datas
-	if (g_io_channel_flush(channel, &error) == G_IO_STATUS_ERROR)
+	// there are three results:
+	//   G_IO_STATUS_AGAIN	this means temporarily anvailable, so try again
+	//   G_IO_STATUS_NORMAL
+	//   G_IO_STATUS_ERROR
+	GIOStatus ioStatus;
+	do {
+		ioStatus = g_io_channel_flush(channel, &error);
+	}
+	while (ioStatus == G_IO_STATUS_AGAIN);
+
+	if (ioStatus == G_IO_STATUS_ERROR)
+	{
 		// main_channel is NULL, so that we don't need to launch clear_channel()
 		return socket_fault(13, error, channel, TRUE);
+	}
+
+	// assert ioStatus == G_IO_STATUS_NORMAL
 
 	g_free(arg_str);
 


### PR DESCRIPTION
These changes fix failing data transport when '\n' is contained in environment data.

The previously used call to g_io_channel_read_line() reads up to the first '\n'.
When this is part of the transported data, it does not get all 12 fields. Using
g_io_channel_read_to_end() fixes this problem. Also deleting the trailing '\n' is
not needed any longer.

Still the protocol is broken, since the field seperator '\012' may not be part of
the data. Some escaping should be employed here.